### PR TITLE
Bug Fix：Depth for treeAggregate

### DIFF
--- a/src/main/scala/com/intel/ssg/bdt/nlp/CRFWithLBFGS.scala
+++ b/src/main/scala/com/intel/ssg/bdt/nlp/CRFWithLBFGS.scala
@@ -165,7 +165,7 @@ private class CostFun(
 
     val bcWeights = taggers.context.broadcast(weigths)
     val n = weigths.length
-    lazy val treeDepth = math.ceil(math.log(taggers.partitions.length) / (math.log(2) * 2)).toInt
+    lazy val treeDepth = math.max(math.ceil(math.log(taggers.partitions.length) / (math.log(2) * 2)).toInt, 2)
 
     val (expected, obj) = taggers.treeAggregate((BDV.zeros[Double](n), 0.0))(
       seqOp = (c, v) => {


### PR DESCRIPTION
In master branch, the treeDepth equals 0 when local mode is set(PS: local model rather than local[*] ) because only one partition exists. This will result in exception when training. And the solution is to set a minimum/default depth which is also the default value for treeAggregate.